### PR TITLE
Bump version number for addition of trackEvent

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-intercom",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "main": "angular-intercom.js",
   "ignore": [
     "**/.*",


### PR DESCRIPTION
The current bower package does not include trackEvent since the version number is unchanged.

A tag for `v0.0.7` would be needed after the merge. Would resolve #6 
