### PR TITLE
Added reattach_activator

### DIFF
--- a/angular-intercom.js
+++ b/angular-intercom.js
@@ -119,6 +119,9 @@
           },
           show: function() {
             intercomInstance('show');
+          },
+          reattachActivator: function() {
+            intercomInstance('reattach_activator');
           }
         }; // end return
       }


### PR DESCRIPTION
The other call is window.Intercom('reattach_activator');. If you remove the element that represents your inbox link from your page and then re-add it, the link between the inbox link and the message box is severed. You’ll need to call window.Intercom('reattach_activator');to set up this binding again.
